### PR TITLE
Add local start script and shell helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ O projeto foi estruturado com uma arquitetura modular, utilizando HTML5, CSS3 e 
 4. Clique em "Calcular" para obter os resultados
 5. Salve o ensaio ou gere um relatório em PDF
 
+## Execução Local
+
+Para servir a aplicação durante o desenvolvimento, utilize o script Node já incluído:
+
+```bash
+npm start
+```
+
+Ele executa `http-server` na pasta `docs` ouvindo a porta `8000`. Usuários Linux ou macOS também podem utilizar o script `start-server.sh`:
+
+```bash
+./start-server.sh
+```
+
+Esse script possui o mesmo comportamento do arquivo `iniciar-servidor.bat` para Windows.
+
 ## Compatibilidade
 
 O aplicativo foi testado e é compatível com:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "npx http-server docs -p 8000"
   },
   "keywords": [],
   "author": "",

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+# Script para iniciar servidor local na pasta docs
+DIR="$(dirname "$0")"
+cd "$DIR/docs"
+URL="http://localhost:8000"
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$URL" 2>/dev/null &
+elif command -v open >/dev/null 2>&1; then
+  open "$URL" 2>/dev/null &
+fi
+python3 -m http.server 8000
+


### PR DESCRIPTION
## Summary
- add `start` script to package.json using `http-server`
- create `start-server.sh` for Unix users
- document the local server in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407f61ca908322b84e20e81e6989b1