### PR TITLE
Fix PDF generator fallback

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -868,7 +868,6 @@
   <!-- Scripts na ordem correta -->
   <!-- Bibliotecas de geração de PDF -->
   <script src="libs/pdf-lib.min.js"></script>
-  <script src="libs/html2pdf.bundle.min.js"></script>
   <script src="js/db.js"></script>
   <script src="js/validation.js"></script>
   <script src="js/densidade-agua.js"></script>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -159,9 +159,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     // Garante que as bibliotecas de geração de PDF estão carregadas
                     try {
                         await loadPdfLib();
-                        if (tipo === 'in-situ') {
-                            await loadHtml2Pdf();
-                        }
                     } catch (e) {
                         window.showToast(e.message, 'error');
                         return;
@@ -359,17 +356,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    async function loadHtml2Pdf() {
-        if (typeof html2pdf === 'undefined') {
-            return new Promise((resolve, reject) => {
-                const script = document.createElement('script');
-                script.src = 'libs/html2pdf.bundle.min.js';
-                script.onload = resolve;
-                script.onerror = () => reject(new Error('Falha ao carregar html2pdf'));
-                document.body.appendChild(script);
-            });
-        }
-    }
+
 
 });
 

--- a/docs/js/pdf-generator.js
+++ b/docs/js/pdf-generator.js
@@ -11,14 +11,7 @@ window.calculadora.pdfGenerator = (() => {
         console.log(`Gerando PDF para ${tipo}:`, dados);
 
         return new Promise(async (resolve, reject) => {
-            if (tipo === 'in-situ' && typeof html2pdf !== 'undefined') {
-                try {
-                    await gerarPDFInSituHTML(dados);
-                    return resolve(true);
-                } catch (err) {
-                    return reject(err);
-                }
-            }
+            // PDF via html2pdf removido por problemas de compatibilidade
 
             // Verificar pdf-lib
             if (typeof PDFLib === 'undefined' || typeof PDFLib.PDFDocument === 'undefined') {


### PR DESCRIPTION
## Summary
- remove html2pdf usage and rely on pdf-lib rendering
- clean up unused html2pdf loader
- drop html2pdf script from index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e92411e48322b7bb5f6251a6a621