### PR TITLE
Improve login UI

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -877,38 +877,40 @@ footer {
     justify-content: center;
     align-items: center;
     padding: 2rem;
-    background-color: var(--primary-light);
+    background: linear-gradient(135deg, var(--primary-light) 0%, #ffffff 100%);
     min-height: 100vh;
 }
 
 #login-container .login-form {
-    background: white;
-    padding: 1rem;
+    background: #ffffff;
+    padding: 2rem 1.5rem;
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);
     width: 100%;
-    max-width: 300px;
+    max-width: 340px;
 }
 
 #login-container input {
     width: 100%;
-    padding: 0.5rem;
-    margin: 0.5rem 0;
-    border: 1px solid var(--primary-color);
+    padding: 0.75rem;
+    margin: 0.6rem 0;
+    border: 1px solid #ccc;
     border-radius: var(--border-radius);
-    background-color: var(--secondary-color);
+    background-color: #fff;
     color: var(--text-color);
+    font-size: 1rem;
 }
 
 #login-container button {
     width: 100%;
-    padding: 0.5rem;
-    margin-top: 0.5rem;
-    border: 1px solid var(--primary-color);
+    padding: 0.75rem;
+    margin-top: 0.8rem;
+    border: none;
     border-radius: var(--border-radius);
     background-color: var(--primary-color);
     color: white;
     cursor: pointer;
+    font-size: 1rem;
     transition: var(--transition);
 }
 
@@ -918,7 +920,7 @@ footer {
 
 #login-container .login-form p {
     text-align: center;
-    margin-top: 0.5rem;
+    margin-top: 1rem;
 }
 
 /* Controle de visibilidade do menu lateral */

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,21 +14,21 @@
   <div id="login-container" class="login-container">
     <div id="login-form" class="login-form">
       <h2>Login</h2>
-      <input type="text" id="login-username" placeholder="Usuário">
-      <input type="password" id="login-password" placeholder="Senha">
+      <input type="email" id="login-username" placeholder="Usuário" autocomplete="username" autofocus>
+      <input type="password" id="login-password" placeholder="Senha" autocomplete="current-password">
       <button id="login-btn">Entrar</button>
       <p><a href="#" id="show-register">Criar Conta</a> | <a href="#" id="show-recover">Recuperar Conta</a></p>
     </div>
     <div id="register-form" class="login-form" style="display:none;">
       <h2>Criar Conta</h2>
-      <input type="text" id="register-username" placeholder="Usuário">
+      <input type="email" id="register-username" placeholder="Usuário" autocomplete="username">
       <input type="password" id="register-password" placeholder="Senha">
       <button id="register-btn">Registrar</button>
       <p><a href="#" class="back-to-login">Voltar para Login</a></p>
     </div>
     <div id="recover-form" class="login-form" style="display:none;">
       <h2>Recuperar Conta</h2>
-      <input type="text" id="recover-username" placeholder="Usuário">
+      <input type="email" id="recover-username" placeholder="Usuário" autocomplete="username">
       <input type="password" id="recover-password" placeholder="Nova Senha">
       <button id="recover-btn">Alterar Senha</button>
       <p><a href="#" class="back-to-login">Voltar para Login</a></p>

--- a/docs/js/login.js
+++ b/docs/js/login.js
@@ -32,7 +32,7 @@
 
   const auth = window.firebaseAuth;
 
-  document.getElementById('register-btn').addEventListener('click', () => {
+  function registrar() {
     const u = document.getElementById('register-username').value.trim();
     const p = document.getElementById('register-password').value;
     if (!u || !p) return alert('Preencha todos os campos');
@@ -42,21 +42,45 @@
         showForm(loginForm);
       })
       .catch(err => alert('Erro ao registrar: ' + err.message));
+  }
+
+  document.getElementById('register-btn').addEventListener('click', registrar);
+  registerForm.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      registrar();
+    }
   });
 
-  document.getElementById('login-btn').addEventListener('click', () => {
+  function logar() {
     const u = document.getElementById('login-username').value.trim();
     const p = document.getElementById('login-password').value;
     auth.signInWithEmailAndPassword(u, p)
       .catch(() => alert('Usuário ou senha inválidos'));
+  }
+
+  document.getElementById('login-btn').addEventListener('click', logar);
+  loginForm.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      logar();
+    }
   });
 
-  document.getElementById('recover-btn').addEventListener('click', () => {
+  function recuperar() {
     const u = document.getElementById('recover-username').value.trim();
     if (!u) return alert('Informe o e-mail');
     auth.sendPasswordResetEmail(u)
       .then(() => alert('Email de recuperação enviado'))
       .catch(err => alert('Erro: ' + err.message));
+  }
+
+  document.getElementById('recover-btn').addEventListener('click', recuperar);
+  recoverForm.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      recuperar();
+    }
   });
 
   logoutBtn.addEventListener('click', () => {

--- a/docs/js/side-menu.js
+++ b/docs/js/side-menu.js
@@ -7,7 +7,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnConcreto = document.getElementById('btn-menu-concreto');
   const toggleBtn = document.getElementById('toggle-sidebar');
 
-  document.body.classList.add('sidebar-visible');
+  if (window.innerWidth < 768) {
+    document.body.classList.add('sidebar-hidden');
+  } else {
+    document.body.classList.add('sidebar-visible');
+  }
 
   toggleBtn?.addEventListener('click', () => {
     document.body.classList.toggle('sidebar-hidden');


### PR DESCRIPTION
## Summary
- refresh login layout and add bigger inputs for better mobile usability
- allow pressing Enter to submit login-related forms
- auto-hide sidebar on small screens
- make email fields use HTML email input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684154b9cda883228dda55741a7fc198