### PR TITLE
Remove manual calculate button and hide UI when printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Execute `iniciar-servidor.bat` no diretório raiz do projeto para abrir o aplica
 1. Acesse o menu principal
 2. Selecione o tipo de ensaio desejado
 3. Preencha os dados de entrada
-4. Clique em "Calcular" para obter os resultados
+4. Os cálculos serão realizados automaticamente
 5. Salve o ensaio ou gere um relatório em PDF
 
 ## Execução Local

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -970,3 +970,16 @@ body.sidebar-hidden footer {
 body.sidebar-hidden .sidebar {
     transform: translateX(-100%);
 }
+
+/* Oculta elementos de navegação e botões ao imprimir */
+@media print {
+    header,
+    footer,
+    nav.sidebar,
+    #toggle-sidebar,
+    .menu-principal,
+    .tabs,
+    .acoes {
+        display: none !important;
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -465,7 +465,6 @@
 
       <!-- Ações -->
       <div class="acoes">
-        <button type="button" class="btn-calcular">Calcular</button>
         <button type="button" class="btn-salvar">Salvar</button>
         <button type="button" class="btn-gerar-pdf">Gerar PDF</button>
         <button type="button" class="btn-limpar">Limpar</button>
@@ -667,7 +666,6 @@
 
       <!-- Ações -->
       <div class="acoes">
-        <button type="button" class="btn-calcular">Calcular</button>
         <button type="button" class="btn-salvar">Salvar</button>
         <button type="button" class="btn-gerar-pdf">Gerar PDF</button>
         <button type="button" class="btn-limpar">Limpar</button>
@@ -862,7 +860,6 @@
 
       <!-- Ações -->
       <div class="acoes">
-        <button type="button" class="btn-calcular">Calcular</button>
         <button type="button" class="btn-salvar">Salvar</button>
         <button type="button" class="btn-gerar-pdf">Gerar PDF</button>
         <button type="button" class="btn-limpar">Limpar</button>


### PR DESCRIPTION
## Summary
- hide navigation and action buttons when printing
- remove the manual `Calcular` button from all forms
- clarify that calculations run automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418282bc348322b1aae1264c88aa3f