### PR TITLE
Add card-style results layout

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -983,3 +983,93 @@ body.sidebar-hidden .sidebar {
         display: none !important;
     }
 }
+/* Layout de resultados em cards */
+.resultados-cards-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.card-resultado {
+    flex: 1 1 calc(33.333% - 20px);
+    min-width: 250px;
+    background-color: #f0f2f5;
+    border-radius: 8px;
+    padding: 15px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    overflow: hidden;
+}
+
+.card-resultado h4 {
+    color: #3f51b5;
+    margin-top: 0;
+    margin-bottom: 15px;
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 8px;
+    font-size: 1.1rem;
+    text-align: center;
+}
+
+.card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.resultado-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 5px;
+}
+
+.resultado-label {
+    flex: 0 0 60%;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 5px;
+}
+
+.resultado-valor {
+    flex: 0 0 40%;
+    display: flex;
+    align-items: center;
+}
+
+.resultado-valor input {
+    width: 100%;
+    text-align: right;
+    padding: 6px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    background-color: #e9ecef;
+}
+
+.resultado-unidade {
+    margin-left: 5px;
+    font-size: 0.85em;
+    color: #666;
+    white-space: nowrap;
+}
+
+.resultado-destaque {
+    background-color: #e8f0fe;
+    border-left: 3px solid #4285f4;
+    padding: 8px;
+    border-radius: 0 4px 4px 0;
+}
+
+@media (max-width: 992px) {
+    .card-resultado {
+        flex: 1 1 calc(50% - 20px);
+    }
+}
+
+@media (max-width: 768px) {
+    .card-resultado {
+        flex: 1 1 100%;
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -426,34 +426,83 @@
 
       <!-- Resultados -->
       <div class="form-section">
-        <h3>Resultados</h3>
-        <div class="table-responsive">
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th></th>
-                <th>Topo</th>
-                <th>Base</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>γd Topo (g/cm³)</td>
-                <td><input type="number" id="gamad-topo" step="0.001" placeholder="0.000" readonly></td>
-                <td><input type="number" id="gamad-base" step="0.001" placeholder="0.000" readonly></td>
-              </tr>
-              <tr>
-                <td>Índice de Vazios</td>
-                <td><input type="number" id="indice-vazios-topo" step="0.01" placeholder="0.00" readonly></td>
-                <td><input type="number" id="indice-vazios-base" step="0.01" placeholder="0.00" readonly></td>
-              </tr>
-              <tr>
-                <td>Compacidade Relativa</td>
-                <td><input type="number" id="cr-topo" step="0.1" placeholder="0.0" readonly></td>
-                <td><input type="number" id="cr-base" step="0.1" placeholder="0.0" readonly></td>
-              </tr>
-            </tbody>
-          </table>
+        <h3>Resultados Finais</h3>
+        <div class="resultados-cards-container">
+          <div class="card-resultado">
+            <h4>Densidades de Referência</h4>
+            <div class="card-content">
+              <div class="resultado-item">
+                <div class="resultado-label">Densidade Real (γs):</div>
+                <div class="resultado-valor">
+                  <input type="number" id="densidade-real" step="0.001" placeholder="0.000" readonly>
+                  <span class="resultado-unidade">g/cm³</span>
+                </div>
+              </div>
+              <div class="resultado-item">
+                <div class="resultado-label">Densidade Máxima (γd máx):</div>
+                <div class="resultado-valor">
+                  <input type="number" id="densidade-max" step="0.001" placeholder="0.000" readonly>
+                  <span class="resultado-unidade">g/cm³</span>
+                </div>
+              </div>
+              <div class="resultado-item">
+                <div class="resultado-label">Densidade Mínima (γd mín):</div>
+                <div class="resultado-valor">
+                  <input type="number" id="densidade-min" step="0.001" placeholder="0.000" readonly>
+                  <span class="resultado-unidade">g/cm³</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="card-resultado">
+            <h4>Compacidade Relativa (CR)</h4>
+            <div class="card-content">
+              <div class="resultado-item">
+                <div class="resultado-label">CR Topo:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="cr-topo" step="0.1" placeholder="0.0" readonly>
+                  <span class="resultado-unidade">%</span>
+                </div>
+              </div>
+              <div class="resultado-item">
+                <div class="resultado-label">CR Base:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="cr-base" step="0.1" placeholder="0.0" readonly>
+                  <span class="resultado-unidade">%</span>
+                </div>
+              </div>
+              <div class="resultado-item resultado-destaque">
+                <div class="resultado-label">CR Média:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="cr-media" step="0.1" placeholder="0.0" readonly>
+                  <span class="resultado-unidade">%</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="card-resultado">
+            <h4>Índice de Vazios (IV)</h4>
+            <div class="card-content">
+              <div class="resultado-item">
+                <div class="resultado-label">IV Topo:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="indice-vazios-topo" step="0.001" placeholder="0.000" readonly>
+                </div>
+              </div>
+              <div class="resultado-item">
+                <div class="resultado-label">IV Base:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="indice-vazios-base" step="0.001" placeholder="0.000" readonly>
+                </div>
+              </div>
+              <div class="resultado-item resultado-destaque">
+                <div class="resultado-label">IV Média:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="iv-media" step="0.001" placeholder="0.000" readonly>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="form-row">
           <div class="status-container">
@@ -644,16 +693,25 @@
       <!-- Resultados finais -->
       <div class="form-section">
         <h3>Resultados</h3>
-        <div class="form-row">
-          <div class="form-group">
-            <label for="diferenca-real">Diferença (g/cm³):</label>
-            <input type="number" id="diferenca-real" step="0.001" placeholder="0.000" readonly>
-          </div>
-        </div>
-        <div class="form-row">
-          <div class="form-group">
-            <label for="media-densidade-real">Média Densidade Real (g/cm³):</label>
-            <input type="number" id="media-densidade-real" step="0.001" placeholder="0.000" readonly>
+        <div class="resultados-cards-container">
+          <div class="card-resultado">
+            <h4>Resultados Finais</h4>
+            <div class="card-content">
+              <div class="resultado-item resultado-destaque">
+                <div class="resultado-label">Densidade Real (γs):</div>
+                <div class="resultado-valor">
+                  <input type="number" id="media-densidade-real" step="0.001" placeholder="0.000" readonly>
+                  <span class="resultado-unidade">g/cm³</span>
+                </div>
+              </div>
+              <div class="resultado-item">
+                <div class="resultado-label">Diferença:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="diferenca-real" step="0.001" placeholder="0.000" readonly>
+                  <span class="resultado-unidade">g/cm³</span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div class="form-row">
@@ -854,6 +912,32 @@
           <div class="form-group">
             <label for="gamad-min">γd mín (g/cm³):</label>
             <input type="number" id="gamad-min" step="0.001" placeholder="0.000" readonly>
+          </div>
+        </div>
+      </div>
+
+      <!-- Resultados -->
+      <div class="form-section">
+        <h3>Resultados</h3>
+        <div class="resultados-cards-container">
+          <div class="card-resultado">
+            <h4>Densidades Finais</h4>
+            <div class="card-content">
+              <div class="resultado-item">
+                <div class="resultado-label">Densidade Máxima:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="gamad-max" step="0.001" placeholder="0.000" readonly>
+                  <span class="resultado-unidade">g/cm³</span>
+                </div>
+              </div>
+              <div class="resultado-item">
+                <div class="resultado-label">Densidade Mínima:</div>
+                <div class="resultado-valor">
+                  <input type="number" id="gamad-min" step="0.001" placeholder="0.000" readonly>
+                  <span class="resultado-unidade">g/cm³</span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/docs/js/form-integration.js
+++ b/docs/js/form-integration.js
@@ -464,6 +464,26 @@ window.calculadora.formIntegration = (function() {
                 fillInput('#cr-base', '', 1);
             }
 
+            // Novos campos de resultados
+            const dr = parseFloat(form.dataset.densidadeReal);
+            const dmax = parseFloat(form.dataset.densidadeMax);
+            const dmin = parseFloat(form.dataset.densidadeMin);
+            if (!isNaN(dr)) fillInput('#densidade-real', dr, 3);
+            if (!isNaN(dmax)) fillInput('#densidade-max', dmax, 3);
+            if (!isNaN(dmin)) fillInput('#densidade-min', dmin, 3);
+
+            if (typeof resultados.compacidadeRelativa?.topo === 'number' && typeof resultados.compacidadeRelativa?.base === 'number') {
+                fillInput('#cr-media', (resultados.compacidadeRelativa.topo + resultados.compacidadeRelativa.base) / 2, 1);
+            } else {
+                fillInput('#cr-media', '', 1);
+            }
+
+            if (typeof resultados.indiceVaziosTopo === 'number' && typeof resultados.indiceVaziosBase === 'number') {
+                fillInput('#iv-media', (resultados.indiceVaziosTopo + resultados.indiceVaziosBase) / 2, 3);
+            } else {
+                fillInput('#iv-media', '', 3);
+            }
+
             if (statusEl) {
                 statusEl.textContent = resultados.status || 'CALCULADO';
                 statusEl.className = resultados.status && resultados.status.includes('APROVADO') ? 'status-aprovado' : 'status-reprovado';


### PR DESCRIPTION
## Summary
- style results with card containers
- show densidade real, densidade máx/mín and averages in In Situ form
- update Densidade Real and Máx/Mín results sections
- fill new fields when displaying results

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ae696e8c8322abeaaccec6f4d1cf