### PR TITLE
Adjust header form layout

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -800,19 +800,22 @@ footer {
 .header-table td {
     padding: 0.4rem;
     vertical-align: top;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 .header-table label {
-    display: block;
-    margin-bottom: 0.3rem;
+    margin: 0;
     font-weight: bold;
     font-size: 0.9rem;
     color: var(--text-color);
+    white-space: nowrap;
 }
 
 .header-table input,
 .header-table select {
-    width: 100%;
+    flex: 1;
     padding: 0.7rem;
     border: 1px solid #ddd;
     border-radius: var(--border-radius);


### PR DESCRIPTION
## Summary
- compress header fields by placing inputs beside labels

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb1bf6a48322a17af7ab6120052f