### PR TITLE
Fix duplicate IDs in max/min density results

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -911,14 +911,14 @@
               <div class="resultado-item">
                 <div class="resultado-label">Densidade Máxima:</div>
                 <div class="resultado-valor">
-                  <input type="number" id="gamad-max" step="0.001" placeholder="0.000" readonly>
+                    <input type="number" id="gamad-max-result" step="0.001" placeholder="0.000" readonly>
                   <span class="resultado-unidade">g/cm³</span>
                 </div>
               </div>
               <div class="resultado-item">
                 <div class="resultado-label">Densidade Mínima:</div>
                 <div class="resultado-valor">
-                  <input type="number" id="gamad-min" step="0.001" placeholder="0.000" readonly>
+                    <input type="number" id="gamad-min-result" step="0.001" placeholder="0.000" readonly>
                   <span class="resultado-unidade">g/cm³</span>
                 </div>
               </div>

--- a/docs/js/form-integration.js
+++ b/docs/js/form-integration.js
@@ -519,7 +519,9 @@ window.calculadora.formIntegration = (function() {
 
             // Resultados Finais Max/Min
             fillInput('#gamad-max', resultados.mediaGamadMax, 3);
+            fillInput('#gamad-max-result', resultados.mediaGamadMax, 3);
             fillInput('#gamad-min', resultados.mediaGamadMin, 3);
+            fillInput('#gamad-min-result', resultados.mediaGamadMin, 3);
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid duplicate element IDs for max/min dry density fields
- update JS integration to fill both table and result cards

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841bd572e088322ac91e99aaa4640d5