### PR TITLE
Fix toast color

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -651,6 +651,10 @@ main {
     opacity: 1;
 }
 
+.toast-info {
+    background-color: var(--primary-color);
+}
+
 
 .toast-success {
     background-color: var(--success-color);


### PR DESCRIPTION
## Summary
- restore `.toast-info` styling so informational toasts use the primary color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68428e020d108322ada8fb119c182354