### PR TITLE
Use dashboard sidebar as main menu

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,36 +71,16 @@
   <div class="app-container">
     <nav class="sidebar">
       <ul>
-        <li><button id="btn-menu-solos" class="sidebar-btn">Solos</button></li>
-        <li><button id="btn-menu-asfalto" class="sidebar-btn">Asfalto</button></li>
-        <li><button id="btn-menu-concreto" class="sidebar-btn">Concreto</button></li>
+        <li><button id="btn-densidade-in-situ" class="sidebar-btn"><i class="fas fa-ruler-vertical"></i> Densidade In Situ</button></li>
+        <li><button id="btn-densidade-real" class="sidebar-btn"><i class="fas fa-balance-scale"></i> Densidade Real</button></li>
+        <li><button id="btn-densidade-max-min" class="sidebar-btn"><i class="fas fa-balance-scale-left"></i> Densidade Máx/Mín</button></li>
+        <li><button id="btn-menu-relatorios" class="sidebar-btn active"><i class="fas fa-file-alt"></i> Relatórios</button></li>
       </ul>
-      <button id="logout-btn" class="btn-logout">Sair</button>
+      <button id="logout-btn" class="btn-logout"><i class="fas fa-sign-out-alt"></i> Sair</button>
     </nav>
 
     <main>
-    <!-- Menu Principal -->
-    <div class="menu-principal">
-      <h2>Selecione o tipo de ensaio</h2>
-      <div class="menu-opcoes">
-        <button id="btn-densidade-in-situ" class="btn-menu">
-          <i class="fas fa-ruler-vertical"></i> Densidade In Situ
-        </button>
-        <button id="btn-densidade-real" class="btn-menu">
-          <i class="fas fa-balance-scale"></i> Densidade Real
-        </button>
-        <button id="btn-densidade-max-min" class="btn-menu">
-          <i class="fas fa-balance-scale-left"></i> Densidade Máxima e Mínima
-        </button>
-      </div>
-    </div>
-
-    <section id="placeholder-asfalto" class="placeholder" style="display:none;">
-      <h2>Em construção: calculadoras de asfalto</h2>
-    </section>
-    <section id="placeholder-concreto" class="placeholder" style="display:none;">
-      <h2>Em construção: calculadoras de concreto</h2>
-    </section>
+    <!-- Conteúdo principal -->
 
     <!-- Seção de Lista de Ensaios -->
     <div id="secao-lista-ensaios" style="display: none;">
@@ -931,7 +911,7 @@
   <script src="js/login.js"></script>
     <script src="js/event-integration.js"></script>
     <script src="js/navigation.js"></script>
-    <script src="js/side-menu.js"></script>
+    <script src="js/dashboard-menu.js"></script>
     <script src="js/app.js"></script>
   </body>
   </html>

--- a/docs/js/login.js
+++ b/docs/js/login.js
@@ -108,7 +108,7 @@
 
   auth.onAuthStateChanged(user => {
     if (user) {
-      window.location.href = 'dashboard.html';
+      window.location.href = 'index.html';
     } else {
       header.style.display = 'none';
       sidebar.style.display = 'none';


### PR DESCRIPTION
## Summary
- switch index sidebar to the dashboard layout and remove old placeholders
- redirect login script to `index.html`
- load `dashboard-menu.js` instead of the deprecated side menu script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684298af00b883229bdfe356643e36d5