### PR TITLE
Remove broken /static links in templates

### DIFF
--- a/docs/templates/densidade_in_situ.html
+++ b/docs/templates/densidade_in_situ.html
@@ -6,7 +6,7 @@
     <title>Densidade In Situ</title>
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
-    <link rel="stylesheet" href="/static/css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css" />
 
     <style>
         .calculadora-container {
@@ -1139,8 +1139,7 @@
         </div>
     </form>
 
-    <!-- Script standalone que funciona independentemente da estrutura de pastas -->
-    <script src="../static/js/calculadora-standalone.js"></script>
+    <!-- Script standalone removido por ausência do arquivo original -->
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             // Verificar se há dados para edição

--- a/docs/templates/densidade_max_min.html
+++ b/docs/templates/densidade_max_min.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Densidade Máxima e Mínima</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/styles.css">
+    <link rel="stylesheet" href="css/styles.css">
     <style>
         .calculadora-container {
             background-color: #fff;
@@ -466,8 +466,7 @@
     <!-- <script src="static/js/calculos.js"></script>
     <script src="static/js/calculos-wrapper.js"></script>
     <script src="static/js/event-handlers.js"></script> -->
-    <!-- Script standalone que funciona independentemente da estrutura de pastas -->
-    <script src="../static/js/calculadora-standalone.js"></script>
+    <!-- Script standalone removido por ausência do arquivo original -->
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             // Verificar se há dados para edição

--- a/docs/templates/densidade_real.html
+++ b/docs/templates/densidade_real.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Densidade Real</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/styles.css">
+    <link rel="stylesheet" href="css/styles.css">
     <style>
         .calculadora-container {
             background-color: #fff;
@@ -483,8 +483,7 @@
     <script src="static/js/calculos-wrapper.js"></script>
     <script src="static/js/event-handlers.js"></script>
     <script src="static/js/calculo-automatico.js"></script> -->
-    <!-- Script standalone que funciona independentemente da estrutura de pastas -->
-    <script src="../static/js/calculadora-standalone.js"></script>
+    <!-- Script standalone removido por ausência do arquivo original -->
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             // Verificar se há dados para edição

--- a/docs/templates/lista_ensaios.html
+++ b/docs/templates/lista_ensaios.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lista de Ensaios</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/styles.css">
+    <link rel="stylesheet" href="css/styles.css">
     <style>
         .lista-container {
             background-color: #fff;


### PR DESCRIPTION
## Summary
- fix paths to CSS in templates so GitHub Pages finds the stylesheets
- drop references to a missing standalone script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d208f7d4832297fbafc45a0afc37