### PR TITLE
Improve template loading guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Execute `iniciar-servidor.bat` no diretório raiz do projeto para abrir o aplica
 4. Os cálculos serão realizados automaticamente
 5. Salve o ensaio ou gere um relatório em PDF
 
+> **Atenção**: não abra `index.html` diretamente pelo navegador. As calculadoras
+são carregadas via `fetch` e, se o arquivo for acessado usando `file://`, os
+templates não serão encontrados e as páginas aparecerão em branco. Sempre utilize
+`npm start` ou outro servidor local para executar a aplicação.
+
 ## Execução Local
 
 Para servir a aplicação durante o desenvolvimento, utilize o script Node já incluído:

--- a/docs/js/template-loader.js
+++ b/docs/js/template-loader.js
@@ -22,6 +22,12 @@
         window.calculadora.templates[key] = await fetchTemplate(file);
       }catch(err){
         console.error('Erro ao carregar template', key, err);
+        const aviso = 'Falha ao carregar templates. Execute a aplicação via \"npm start\"';
+        if (typeof window.showToast === 'function') {
+          window.showToast(aviso, 'error', 5000);
+        } else {
+          alert(aviso);
+        }
       }
     }
     window.calculadora.templatesLoaded = true;


### PR DESCRIPTION
## Summary
- warn users in README not to open index.html directly
- show notification when templates fail to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842dffa60548322bf8959f617fb4b5c