### PR TITLE
Fix template path for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ são carregadas via `fetch` e, se o arquivo for acessado usando `file://`, os
 templates não serão encontrados e as páginas aparecerão em branco. Sempre utilize
 `npm start` ou outro servidor local para executar a aplicação.
 
+Ao publicar em serviços como **GitHub Pages**, defina a pasta `docs` como raiz do
+site. Os formulários são buscados em `./templates` e precisam estar acessíveis no
+mesmo caminho para que a aplicação funcione corretamente.
+
 ## Execução Local
 
 Para servir a aplicação durante o desenvolvimento, utilize o script Node já incluído:

--- a/docs/js/template-loader.js
+++ b/docs/js/template-loader.js
@@ -2,7 +2,7 @@
   window.calculadora = window.calculadora || {};
 
   async function fetchTemplate(file){
-    const resp = await fetch(`templates/${file}`);
+    const resp = await fetch(`./templates/${file}`);
     const text = await resp.text();
     const parser = new DOMParser();
     const doc = parser.parseFromString(text, 'text/html');


### PR DESCRIPTION
## Summary
- fetch templates using explicit `./templates/` path
- add note in README about configuring GitHub Pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842eda755508322ac87ceae7563605c