### PR TITLE
Corrige IDs de cabecalho nos templates

### DIFF
--- a/docs/templates/densidade_max_min.html
+++ b/docs/templates/densidade_max_min.html
@@ -289,26 +289,26 @@
             <table class="header-table">
                 <tr>
                     <td>
-                        <label for="registro">Número do Registro:</label>
-                        <input type="text" id="registro" name="registro" placeholder="Informe o número do registro">
+                        <label for="registro-max-min">Número do Registro:</label>
+                        <input type="text" id="registro-max-min" name="registro" placeholder="Informe o número do registro">
                     </td>
                     <td>
-                        <label for="data">Data:</label>
-                        <input type="date" id="data" name="data">
+                        <label for="data-max-min">Data:</label>
+                        <input type="date" id="data-max-min" name="data">
                     </td>
                     <td>
-                        <label for="operador">Operador:</label>
-                        <input type="text" id="operador" name="operador" placeholder="Nome do operador">
+                        <label for="operador-max-min">Operador:</label>
+                        <input type="text" id="operador-max-min" name="operador" placeholder="Nome do operador">
                     </td>
                     <td>
-                        <label for="material">Material:</label>
-                        <input type="text" id="material" name="material" placeholder="Descrição do material">
+                        <label for="material-max-min">Material:</label>
+                        <input type="text" id="material-max-min" name="material" placeholder="Descrição do material">
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="origem">Origem:</label>
-                        <input type="text" id="origem" name="origem" placeholder="Origem do material">
+                        <label for="origem-max-min">Origem:</label>
+                        <input type="text" id="origem-max-min" name="origem" placeholder="Origem do material">
                     </td>
                     <td></td>
                     <td></td>
@@ -480,11 +480,11 @@
                 console.log('Preenchendo formulário com dados:', dados);
 
                 // Preencher campos de informações gerais
-                document.getElementById('registro').value = dados.registro || '';
-                document.getElementById('data').value = dados.data || '';
-                document.getElementById('operador').value = dados.operador || '';
-                document.getElementById('material').value = dados.material || '';
-                document.getElementById('origem').value = dados.origem || '';
+                document.getElementById('registro-max-min').value = dados.registro || '';
+                document.getElementById('data-max-min').value = dados.data || '';
+                document.getElementById('operador-max-min').value = dados.operador || '';
+                document.getElementById('material-max-min').value = dados.material || '';
+                document.getElementById('origem-max-min').value = dados.origem || '';
 
                 // Preencher determinações de densidade máxima
                 if (dados.determinacoesDensidadeMax && dados.determinacoesDensidadeMax.length >= 2) {

--- a/docs/templates/densidade_real.html
+++ b/docs/templates/densidade_real.html
@@ -289,26 +289,26 @@
             <table class="header-table">
                 <tr>
                     <td>
-                        <label for="registro">Número do Registro:</label>
-                        <input type="text" id="registro" name="registro" placeholder="Informe o número do registro">
+                        <label for="registro-real">Número do Registro:</label>
+                        <input type="text" id="registro-real" name="registro" placeholder="Informe o número do registro">
                     </td>
                     <td>
-                        <label for="data">Data:</label>
-                        <input type="date" id="data" name="data">
+                        <label for="data-real">Data:</label>
+                        <input type="date" id="data-real" name="data">
                     </td>
                     <td>
-                        <label for="operador">Operador:</label>
-                        <input type="text" id="operador" name="operador" placeholder="Nome do operador">
+                        <label for="operador-real">Operador:</label>
+                        <input type="text" id="operador-real" name="operador" placeholder="Nome do operador">
                     </td>
                     <td>
-                        <label for="material">Material:</label>
-                        <input type="text" id="material" name="material" placeholder="Descrição do material">
+                        <label for="material-real">Material:</label>
+                        <input type="text" id="material-real" name="material" placeholder="Descrição do material">
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="origem">Origem:</label>
-                        <input type="text" id="origem" name="origem" placeholder="Origem do material">
+                        <label for="origem-real">Origem:</label>
+                        <input type="text" id="origem-real" name="origem" placeholder="Origem do material">
                     </td>
                     <td></td>
                     <td></td>
@@ -497,11 +497,11 @@
                 console.log('Preenchendo formulário com dados:', dados);
 
                 // Preencher campos de informações gerais
-                document.getElementById('registro').value = dados.registro || '';
-                document.getElementById('data').value = dados.data || '';
-                document.getElementById('operador').value = dados.operador || '';
-                document.getElementById('material').value = dados.material || '';
-                document.getElementById('origem').value = dados.origem || '';
+                document.getElementById('registro-real').value = dados.registro || '';
+                document.getElementById('data-real').value = dados.data || '';
+                document.getElementById('operador-real').value = dados.operador || '';
+                document.getElementById('material-real').value = dados.material || '';
+                document.getElementById('origem-real').value = dados.origem || '';
 
                 // Preencher determinações de umidade
                 for (let i = 1; i <= 3; i++) {


### PR DESCRIPTION
## Summary
- update real and max/min HTML templates to use suffix IDs expected by JS

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1c4125c8322ba65af1c08fd6a6a