### PR TITLE
Fix sidebar layout on mobile

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -111,6 +111,22 @@ header {
   margin-left: 1rem;
 }
 
+/* Header simplificado da página principal */
+.simple-header {
+  justify-content: center;
+  position: relative;
+}
+
+.simple-header h1 {
+  flex: 1;
+  text-align: center;
+}
+
+.simple-header .toggle-sidebar {
+  position: absolute;
+  left: 1rem;
+}
+
 /* Layout com menu lateral */
 .app-container {
     display: flex;
@@ -1036,8 +1052,14 @@ footer {
 
 /* Controle de visibilidade do menu lateral */
 body.sidebar-visible main {
-    padding-left: 180px;
+    padding-left: 0;
     transition: padding-left 0.3s ease;
+}
+
+@media (min-width: 768px) {
+    body.sidebar-visible main {
+        padding-left: 180px;
+    }
 }
 
 body.sidebar-visible header,

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
       <p><a href="#" class="back-to-login">Voltar para Login</a></p>
     </div>
   </div>
-  <header>
+  <header class="simple-header">
     <button id="toggle-sidebar" class="toggle-sidebar"><i class="fas fa-bars"></i></button>
     <h1>Laboratório Ev.C.S</h1>
   </header>


### PR DESCRIPTION
## Summary
- style header on main page and center the title
- avoid shrinking main content when the sidebar is open on mobile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684315f8f0f883228299ec87cad62c45