### PR TITLE
Fix fixed header and visible footer on legal pages

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -1049,6 +1049,13 @@ footer {
     font-size: 0.8rem;
     color: #888;
 }
+/* Documentos Legais */
+.legal-document {
+    padding: calc(var(--header-height) + 1rem) 1.5rem calc(var(--footer-height) + 1rem);
+    max-width: 800px;
+    margin: 0 auto;
+}
+
 
 /* Controle de visibilidade do menu lateral */
 body.sidebar-visible main {

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -7,6 +7,9 @@
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
+  <header class="simple-header">
+    <h1>Laboratório Ev.C.S</h1>
+  </header>
   <div class="legal-document">
     <h1>Política de Privacidade</h1>
     <p>Última atualização: [DATA]</p>
@@ -94,5 +97,12 @@
       <p>Telefone: [TELEFONE]</p>
     </section>
   </div>
+  <footer>
+    <div>© 2025 Laboratório Ev.C.S - Versão 2.0</div>
+    <div>
+      <a href="privacy-policy.html">Política de Privacidade</a> |
+      <a href="terms-of-use.html">Termos de Uso</a>
+    </div>
+  </footer>
 </body>
 </html>

--- a/docs/terms-of-use.html
+++ b/docs/terms-of-use.html
@@ -7,6 +7,9 @@
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
+  <header class="simple-header">
+    <h1>Laboratório Ev.C.S</h1>
+  </header>
   <div class="legal-document">
     <h1>Termos de Uso</h1>
     <p>Última atualização: [DATA]</p>
@@ -84,5 +87,12 @@
       <p>Telefone: [TELEFONE]</p>
     </section>
   </div>
+  <footer>
+    <div>© 2025 Laboratório Ev.C.S - Versão 2.0</div>
+    <div>
+      <a href="privacy-policy.html">Política de Privacidade</a> |
+      <a href="terms-of-use.html">Termos de Uso</a>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep header fixed for legal docs
- show footer links in policy documents
- style legal document layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684317b4ff8883229d59c2991053931b