### PR TITLE
Fix login flicker on refresh

### DIFF
--- a/docs/js/login.js
+++ b/docs/js/login.js
@@ -89,12 +89,12 @@
      auth.signOut();
    });
 
-   header.style.display = 'none';
-   sidebar.style.display = 'none';
-   main.style.display = 'none';
-   footer.style.display = 'none';
-   loginContainer.style.display = 'flex';
-   showForm(loginForm);
+  header.style.display = 'none';
+  sidebar.style.display = 'none';
+  main.style.display = 'none';
+  footer.style.display = 'none';
+  loginContainer.style.display = 'none';
+  showForm(loginForm);
 
    auth.onAuthStateChanged(user => {
      if (user) {


### PR DESCRIPTION
## Summary
- fix flicker between login and main app by keeping login screen hidden until auth state is determined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843239e6688832283949a6014155c38