### PR TITLE
Update result tables and header info

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -113,7 +113,7 @@ header {
 
 /* Header simplificado da página principal */
 .simple-header {
-  justify-content: center;
+  justify-content: space-between;
   position: relative;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,9 @@
   <header class="simple-header">
     <button id="toggle-sidebar" class="toggle-sidebar"><i class="fas fa-bars"></i></button>
     <h1>Laboratório Ev.C.S</h1>
+    <div class="header-right">
+      <span class="user-info"><span id="current-user-name"></span> <span class="status-indicator"></span></span>
+    </div>
   </header>
 
   <div class="app-container">

--- a/docs/js/form-integration.js
+++ b/docs/js/form-integration.js
@@ -111,18 +111,7 @@ window.calculadora.formIntegration = (function() {
             return;
         }
 
-        // Adiciona um botão de voltar se não existir
-        if (!form.querySelector('.btn-voltar')) {
-            const btnVoltar = document.createElement('button');
-            btnVoltar.type = 'button';
-            btnVoltar.className = 'btn-voltar';
-            btnVoltar.innerHTML = '<i class="fas fa-arrow-left"></i> Voltar para Lista';
-            // Adiciona o botão antes das ações
-            const acoesDiv = form.querySelector('.acoes');
-            if (acoesDiv) {
-                form.insertBefore(btnVoltar, acoesDiv);
-            }
-        }
+
 
         // Carrega dados de referência se for 'in-situ'
         if (tipo === 'in-situ') {

--- a/docs/js/login.js
+++ b/docs/js/login.js
@@ -118,9 +118,9 @@
      }
    });
 
-   logoutBtn.addEventListener('click', () => {
-     auth.signOut();
-   });
+  logoutBtn.addEventListener('click', () => {
+    auth.signOut();
+  });
 
   header.style.display = 'none';
   sidebar.style.display = 'none';
@@ -129,20 +129,24 @@
   loginContainer.style.display = 'none';
   showForm(loginForm);
 
-   auth.onAuthStateChanged(user => {
-     if (user) {
-       header.style.display = '';
-       sidebar.style.display = '';
-       main.style.display = '';
-       footer.style.display = '';
-       loginContainer.style.display = 'none';
-     } else {
-       header.style.display = 'none';
-       sidebar.style.display = 'none';
-       main.style.display = 'none';
-       footer.style.display = 'none';
-       loginContainer.style.display = 'flex';
-       showForm(loginForm);
-     }
-   });
+  auth.onAuthStateChanged(user => {
+    if (user) {
+      header.style.display = '';
+      sidebar.style.display = '';
+      main.style.display = '';
+      footer.style.display = '';
+      loginContainer.style.display = 'none';
+      const nameEl = document.getElementById('current-user-name');
+      if (nameEl) nameEl.textContent = user.email || user.displayName || 'Usuário';
+    } else {
+      header.style.display = 'none';
+      sidebar.style.display = 'none';
+      main.style.display = 'none';
+      footer.style.display = 'none';
+      loginContainer.style.display = 'flex';
+      showForm(loginForm);
+      const nameEl = document.getElementById('current-user-name');
+      if (nameEl) nameEl.textContent = '';
+    }
+  });
  });

--- a/docs/templates/densidade_real.html
+++ b/docs/templates/densidade_real.html
@@ -447,26 +447,25 @@
         <!-- Resultados -->
         <div class="form-section">
             <h3>Resultados</h3>
-            <div class="resultados-cards-container">
-                <div class="card-resultado">
-                    <h4>Resultados Finais</h4>
-                    <div class="card-content">
-                        <div class="resultado-item resultado-destaque">
-                            <div class="resultado-label">Densidade Real (γs):</div>
-                            <div class="resultado-valor">
+            <div class="table-responsive">
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <td>Densidade Real (γs)</td>
+                            <td>
                                 <input type="number" id="densidade-real-final" name="densidade-real-final" step="0.001" placeholder="0.000" readonly>
                                 <span class="resultado-unidade">g/cm³</span>
-                            </div>
-                        </div>
-                        <div class="resultado-item">
-                            <div class="resultado-label">Diferença:</div>
-                            <div class="resultado-valor">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Diferença</td>
+                            <td>
                                 <input type="number" id="diferenca" name="diferenca" step="0.01" placeholder="0.00" readonly>
                                 <span class="resultado-unidade">%</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add user status indicator and name to header
- update login script to fill in logged name
- remove dynamic creation of 'voltar para lista' button
- show results of Densidade Real in a two column table
- adjust header layout for right-aligned info

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684332b090c48322b1a86c517d23bc9a