### PR TITLE
Fix densidade in situ PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ Esse script possui o mesmo comportamento do arquivo `iniciar-servidor.bat` para 
 
 ## Geração de PDF
 
-Ao gerar relatórios o sistema utiliza as bibliotecas **pdf-lib** e **html2pdf**.
-Esses arquivos são carregados automaticamente em tempo de execução caso ainda
-não estejam presentes na página. É necessário conexão com a internet ou cópias
-locais dessas bibliotecas para que o processo funcione corretamente.
+Ao gerar relatórios o sistema utiliza a biblioteca **html2pdf**, que encapsula
+as dependências **html2canvas** e **jsPDF** para compor e salvar o arquivo PDF.
+Esse script é carregado automaticamente em tempo de execução caso ainda não
+esteja presente na página. É necessário conexão com a internet ou cópias locais
+dessas bibliotecas para que o processo funcione corretamente.
 
 ## Compatibilidade
 

--- a/docs/js/pdf-generator.js
+++ b/docs/js/pdf-generator.js
@@ -10,6 +10,12 @@ window.calculadora.pdfGenerator = (() => {
     function gerarPDF(tipo, dados) {
         console.log(`Gerando PDF via HTML para ${tipo}:`, dados);
 
+        // Para o ensaio "in-situ" usamos um template dedicado para evitar
+        // quebra incorreta do cabeçalho no PDF.
+        if (tipo === 'in-situ') {
+            return gerarPDFInSituHTML(dados);
+        }
+
         return new Promise((resolve, reject) => {
             if (typeof html2pdf === 'undefined') {
                 return reject(new Error('html2pdf não carregado'));
@@ -477,7 +483,8 @@ window.calculadora.pdfGenerator = (() => {
                 filename:     `in-situ_${dados.registro || 'sem_registro'}.pdf`,
                 image:        { type: 'jpeg', quality: 0.98 },
                 html2canvas:  { scale: 2 },
-                jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' }
+                jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' },
+                pagebreak:    { mode: 'css' }
             };
 
             html2pdf().set(opt).from(container).save().then(() => {
@@ -562,6 +569,7 @@ th,td{border:1px dashed #000;padding:4px 6px;text-align:center;font-size:11px}
 th{background:#eee;font-weight:bold}
 .table-caption{text-align:center;font-size:12px;font-weight:bold;margin-bottom:4px}
 .footer-text{font-size:9px;text-align:center;margin-top:20px}
+.pagebreak{page-break-before:always}
 </style></head><body>
 <div class="section">
 <div class="center"><h2>DETERMINAÇÃO DA COMPACTAÇÃO RELATIVA</h2><p style="font-size:10px;font-style:italic;">NBR 6457:2024 – NBR 9813:2016</p></div>


### PR DESCRIPTION
## Summary
- avoid blank pages when generating PDF for ensaio in-situ
- force pagebreak handling with CSS rule
- update README about the PDF library usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68434f2d3fec8322904bf4ab6d269c8d