### PR TITLE
Improve PDF generation reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ Ao gerar relatórios o sistema utiliza a biblioteca **html2pdf**, que encapsula
 as dependências **html2canvas** e **jsPDF** para compor e salvar o arquivo PDF.
 Esse script é carregado automaticamente em tempo de execução caso ainda não
 esteja presente na página. É necessário conexão com a internet ou cópias locais
-dessas bibliotecas para que o processo funcione corretamente.
+dessas bibliotecas para que o processo funcione corretamente. Caso o PDF seja
+gerado em branco, certifique-se de estar executando a aplicação via servidor
+(por exemplo, com `npm start`) para evitar problemas de CORS durante a captura
+da página.
 
 ## Compatibilidade
 

--- a/docs/js/pdf-generator.js
+++ b/docs/js/pdf-generator.js
@@ -48,7 +48,7 @@ window.calculadora.pdfGenerator = (() => {
             const opt = {
                 margin: 10,
                 filename: `${tipo}_${dados.registro || 'sem_registro'}.pdf`,
-                html2canvas: { scale: 2 },
+                html2canvas: { scale: 2, useCORS: true },
                 jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
             };
 
@@ -482,9 +482,9 @@ window.calculadora.pdfGenerator = (() => {
                 margin:       0,
                 filename:     `in-situ_${dados.registro || 'sem_registro'}.pdf`,
                 image:        { type: 'jpeg', quality: 0.98 },
-                html2canvas:  { scale: 2 },
+                html2canvas:  { scale: 2, useCORS: true },
                 jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' },
-                pagebreak:    { mode: 'css' }
+                pagebreak:    { mode: ['css', 'legacy'] }
             };
 
             html2pdf().set(opt).from(container).save().then(() => {


### PR DESCRIPTION
## Summary
- update README with hint for blank PDF
- ensure html2canvas uses CORS and enable legacy pagebreak mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684353a782308322a60950ae554c3b8d